### PR TITLE
Release 2.0.1

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -163,8 +163,10 @@ protocols: [HTTPS]
           204:
           400:
             description: |
-              The request body was invlalid, such as if no `code` value was found.
+              The request body was invalid, such as if no `code` value was found.
           401:
+            description: |
+              The given TOTP code was wrong.
           404:
 
 /u2f:

--- a/api.raml
+++ b/api.raml
@@ -160,7 +160,9 @@ protocols: [HTTPS]
             example: |
               {"code": "012345"}
         responses:
-          204:
+          200:
+            description: |
+              The given TOTP code was valid.
           400:
             description: |
               The request body was invalid, such as if no `code` value was found.

--- a/models/totp.js
+++ b/models/totp.js
@@ -20,13 +20,17 @@ module.exports.create = (apiKeyValue, apiSecret, {issuer, label = 'SecretKey'} =
     
     const otpSecrets = speakeasy.generateSecret({length: 10});
     let otpAuthUrlOptions = {
-      'label': label,
+      'label': encodeURIComponent(label),
       'secret': otpSecrets.base32,
       'encoding': 'base32'
     };
     if (issuer) {
       otpAuthUrlOptions.issuer = issuer;
-      otpAuthUrlOptions.label = issuer + ':' + label;
+      
+      // Note: The issuer and account-name used in the `label` need to be
+      // URL-encoded. Presumably speakeasy doesn't automatically do so because
+      // the colon (:) separating them needs to NOT be encoded.
+      otpAuthUrlOptions.label = encodeURIComponent(issuer) + ':' + encodeURIComponent(label);
     }
     
     const otpAuthUrl = speakeasy.otpauthURL(otpAuthUrlOptions);


### PR DESCRIPTION
This is running and working in dev (tested via the AppsDev IdP).

It seems to fix the non-encoded space issue that causes Authy and Google Authenticator on iOS to reject the QR codes generated when the issuer (e.g. "Example Org") contain a space.

It also fixes some minor problems with the API's RAML spec.