### PR TITLE
Release 2.1.1

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+{
+  "generalSettings": {
+    "shouldScanRepo": true
+  },
+  "checkRunSettings": {
+    "vulnerableCheckRunConclusionLevel": "failure"
+  }
+}


### PR DESCRIPTION
**Security:**
- Update lodash (used by local testing framework, not in production) to get past published vulnerability.

---

The lodash vulnerability does not seem to be exposed in any way in our system, but it is nonetheless being reported to us since we use lodash as a (sub) (dev-)dependency, so it seems worth updating.