### PR TITLE
Return 400 (instead of crashing) if no appId given in POST /u2f

### DIFF
--- a/models/u2f.js
+++ b/models/u2f.js
@@ -116,6 +116,11 @@ module.exports.createRegistration = (apiKeyValue, apiSecret, {appId} = {}, callb
       return;
     }
 
+    if ((!appId) || typeof appId !== 'string') {
+      response.returnError(400, 'appId is required', callback);
+      return;
+    }
+
     const registrationRequest = u2f.request(appId);
 
     const u2fUuid = uuid.v4();


### PR DESCRIPTION
**Fixed:**

- Return 400 (instead of crashing) if no appId given in POST /u2f

---

I think this was just an oversight, not an intentional hiding of the cause of an error (as is sometimes done in the code, but in those places we return a 401 Unauthorized).