### PR TITLE
Specify Serverless Framework version during CI/CD, to fix builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,15 @@ jspm_packages
 
 # Temporary copy of backups (used during Disaster Recovery)
 /recovery/TempCopyOfBackups
+
+# JS files generated or copied during local development (see Makefile)
+/development/site/client-bundle.js
+/development/site/psl.min.js
+/development/site/webauthn-client.js
+
+# Folder with cert files used for dev-server https-proxy / traefik
+development/cert
+
+# Local environment variables files, typically with secrets
+local.env
+*.local.env

--- a/codeship/setup.sh
+++ b/codeship/setup.sh
@@ -3,5 +3,5 @@
 # Exit script with error if any step fails.
 set -e
 
-npm install -g serverless
+npm install -g serverless@1
 npm install


### PR DESCRIPTION
### Fixed
- Update CI/CD "setup.sh" script to specify the version of Serverless Framework to use
- Ignore more files that shouldn't be versioned (in case they're present)