### PR TITLE
Add more documentation for how to run this locally (for development, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,11 @@ gulp restore \
 To run this locally (such as for development)...
 
 1. Open a terminal to **THIS** repo's root folder and run the following:
-   - `make dynamodb-tables` (NOTE: You may need to run this twice.)
+   - `make dynamodb-tables`
+     * NOTE: You may need to run this twice. If it gives an error message,
+       trying again should work. I think it's a timing issue, where it tries to
+       create the dynamodb tables before the local dynamodb is _actually_ up
+       enough to be ready for interaction.
    - `make dev-server`
 2. Add and activate api-key entry for yourself in your local serverless-mfa-api:
    - Submit a `POST` to <https://localhost:8080/prod/api-key> with a JSON body

--- a/README.md
+++ b/README.md
@@ -262,6 +262,49 @@ gulp restore \
 ```
 (Note: The restore time is a JavaScript timestamp, in milliseconds.)
 
+## Running locally
+
+To run this locally (such as for development)...
+
+1. Open a terminal to **THIS** repo's root folder and run the following:
+   - `make dynamodb-tables` (NOTE: You may need to run this twice.)
+   - `make dev-server`
+2. Add and activate api-key entry for yourself in your local serverless-mfa-api:
+   - Submit a `POST` to <https://localhost:8080/prod/api-key> with a JSON body
+     like the following:
+     ```json
+     { "email": "local@example.com" }
+     ```
+     It should return a `204 No Content` response.
+   - Run `make list-dev-api-keys`, and copy the "value" parameter's value.
+   - Do a `POST` to <https://localhost:8080/prod/api-key/activate>, with a JSON
+     body like the following:
+     ```json
+     {
+     "email": "local@example.com",
+     "apiKey": "the-value-parameter-from-the-dynamo-db-table"
+     }
+     ```
+     It should return a `200 OK` with a JSON body containing an apiSecret that
+     you will need. When copying that value, make sure you include any trailing
+     equals signs (`=`).
+3. Clone the <https://github.com/silinternational/idp-in-a-box> repo.
+4. Put the apiSecret returned (including any trailing `=` signs) and the apiKey
+   value you used in the JSON body into your local idp-in-a-box code's
+   `/docker-compose/broker/local.env` file, both for the `MFA_TOTP_*` and
+   `MFA_U2F_*` environment variables, something like this (but using **YOUR**
+   values for the apiKey and apiSecret entries, not these dummy/sample values):
+   ```
+   MFA_TOTP_apiBaseUrl=http://localhost:8080/
+   MFA_TOTP_apiKey=347a15dc60f014bdd93e4fc59aab607b022c8e19
+   MFA_TOTP_apiSecret=za3c5Op8XgQcWNK16Rg6Th3ndmJ2ZTGL4uEldAJxDes=
+   
+   MFA_U2F_apiBaseUrl=http://localhost:8080/
+   MFA_U2F_apiKey=347a15dc60f014bdd93e4fc59aab607b022c8e19
+   MFA_U2F_apiSecret=za3c5Op8XgQcWNK16Rg6Th3ndmJ2ZTGL4uEldAJxDes= 
+   ```
+5. Bring up the `idp-in-a-box` repo. See that repo's README.md for instructions.
+
 ## Glossary
 
 - `API Key`: A hex string used to identify calls to most of the endpoints on


### PR DESCRIPTION
### Fixed
- Improve documentation for running the Serverless-MFA-API locally