### PR TITLE
Force recovery process to use Serverless Framework version 1

### DIFF
--- a/recovery/Dockerfile
+++ b/recovery/Dockerfile
@@ -6,4 +6,4 @@ RUN unzip awscli-bundle.zip
 RUN ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
 # Install the Serverless Framework
-RUN npm install -g serverless
+RUN npm install -g serverless@1


### PR DESCRIPTION
### Fixed
- Force recovery process to use Serverless Framework version 1

---

I haven't tested this yet, either before or after, but we made [this same change](https://github.com/silinternational/serverless-mfa-api/commit/e9f8df72c9888dbbe290a596009dc86fe73181ca#diff-e1685bd1c344b437e6ef39904695de11d2df2b62d7a4ee686a71e806858df1ed) in the commands our CI/CD process uses because that's the version of the Serverless Framework that our code currently uses.