### PR TITLE
Use Node JS 16 for CI/CD tests

### DIFF
--- a/codeship/setup.sh
+++ b/codeship/setup.sh
@@ -3,9 +3,8 @@
 # Exit script with error if any step fails.
 set -e
 
-# Specify the desired version of NodeJS. Should match package.json, Dockerfiles,
-# and serverless.yml file.
-nvm use 16
+# Check which version of NodeJS we're running.
+node --version
 
 npm ci --no-fund -g serverless@3
 npm ci --no-fund

--- a/codeship/setup.sh
+++ b/codeship/setup.sh
@@ -7,5 +7,5 @@ set -e
 # and serverless.yml file.
 nvm use 16
 
-npm install --no-fund -g serverless@3
-npm install --no-fund
+npm ci --no-fund -g serverless@3
+npm ci --no-fund

--- a/codeship/setup.sh
+++ b/codeship/setup.sh
@@ -3,5 +3,9 @@
 # Exit script with error if any step fails.
 set -e
 
+# Specify the desired version of NodeJS. Should match package.json, Dockerfiles,
+# and serverless.yml file.
+nvm use 16
+
 npm install --no-fund -g serverless@3
 npm install --no-fund

--- a/codeship/setup.sh
+++ b/codeship/setup.sh
@@ -6,5 +6,5 @@ set -e
 # Check which version of NodeJS we're running.
 node --version
 
-npm ci --no-fund -g serverless@3
+npm install --no-fund -g serverless@3
 npm ci --no-fund


### PR DESCRIPTION
### Fixed
- Make it easier to see NodeJS version used on Codeship.
  - It turns out it will match the constraints defined in the package.json file ([docs](https://docs.cloudbees.com/docs/cloudbees-codeship/latest/basic-languages-frameworks/nodejs))
- Use `npm ci` ([docs](https://docs.npmjs.com/cli/v8/commands/npm-ci)) for installing package.json dependencies during CI/CD processes