### PR TITLE
Release 2.3.3 - Update NodeJS

### DIFF
--- a/codeship/setup.sh
+++ b/codeship/setup.sh
@@ -3,5 +3,5 @@
 # Exit script with error if any step fails.
 set -e
 
-npm install -g serverless@3.7
-npm install
+npm install --no-fund -g serverless@3
+npm install --no-fund

--- a/recovery/Dockerfile
+++ b/recovery/Dockerfile
@@ -6,4 +6,4 @@ RUN unzip awscli-bundle.zip
 RUN ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
 # Install the Serverless Framework
-RUN npm install -g serverless@1
+RUN npm install -g serverless@3

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,6 @@
 service: mfa-api
 
-frameworkVersion: ^3.7.0
+frameworkVersion: ^3.7
 
 provider:
   name: aws

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,13 +4,11 @@
  */
 module "serverless-user" {
   source  = "silinternational/serverless-user/aws"
-  version = "0.1.0"
+  version = "0.1.1"
 
   app_name           = "mfa-api"
   aws_region         = var.aws_region
   enable_api_gateway = true
-
-  extra_policies = [local.s3_policy]
 }
 
 output "serverless-access-key-id" {
@@ -19,22 +17,4 @@ output "serverless-access-key-id" {
 output "serverless-secret-access-key" {
   value     = module.serverless-user.aws_secret_access_key
   sensitive = true
-}
-
-
-locals {
-  s3_policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "s3:GetBucketPolicy",
-        ],
-        "Resource" : [
-          "arn:aws:s3:::mfa-api-*-serverlessdeploymentbucket*",
-        ]
-      },
-    ]
-  })
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,8 @@ module "serverless-user" {
   app_name           = "mfa-api"
   aws_region         = var.aws_region
   enable_api_gateway = true
+
+  extra_policies = [local.s3_policy]
 }
 
 output "serverless-access-key-id" {
@@ -17,4 +19,34 @@ output "serverless-access-key-id" {
 output "serverless-secret-access-key" {
   value     = module.serverless-user.aws_secret_access_key
   sensitive = true
+}
+
+
+locals {
+  s3_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:GetBucketPolicy",
+        ],
+        "Resource" : [
+          "arn:aws:s3:::mfa-api-*-serverlessdeploymentbucket*"
+        ]
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "apigateway:UpdateRestApiPolicy",
+        ],
+        "Resource" : [
+          // dev-mfa-api
+          "arn:aws:apigateway:${var.aws_region}:*:restapis/7f2jflg37i",
+          // prod-mfa-api
+          "arn:aws:apigateway:${var.aws_region}:*:restapis/7hk96xvik6",
+        ]
+      },
+    ]
+  })
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ module "serverless-user" {
   aws_region         = var.aws_region
   enable_api_gateway = true
 
-  extra_policies = [local.s3_policy]
+  extra_policies = [local.s3_policy, local.api_gateway_policy]
 }
 
 output "serverless-access-key-id" {
@@ -32,9 +32,15 @@ locals {
           "s3:GetBucketPolicy",
         ],
         "Resource" : [
-          "arn:aws:s3:::mfa-api-*-serverlessdeploymentbucket*"
+          "arn:aws:s3:::mfa-api-*-serverlessdeploymentbucket*",
         ]
       },
+    ]
+  })
+
+  api_gateway_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
       {
         "Effect" : "Allow",
         "Action" : [

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ module "serverless-user" {
   aws_region         = var.aws_region
   enable_api_gateway = true
 
-  extra_policies = [local.s3_policy, local.api_gateway_policy]
+  extra_policies = [local.s3_policy]
 }
 
 output "serverless-access-key-id" {
@@ -33,24 +33,6 @@ locals {
         ],
         "Resource" : [
           "arn:aws:s3:::mfa-api-*-serverlessdeploymentbucket*",
-        ]
-      },
-    ]
-  })
-
-  api_gateway_policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "apigateway:UpdateRestApiPolicy",
-        ],
-        "Resource" : [
-          // dev-mfa-api
-          "arn:aws:apigateway:${var.aws_region}:*:restapis/7f2jflg37i",
-          // prod-mfa-api
-          "arn:aws:apigateway:${var.aws_region}:*:restapis/7hk96xvik6",
         ]
       },
     ]

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,5 +1,5 @@
 provider "aws" {
   region     = var.aws_region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,8 +2,8 @@ variable "aws_region" {
   default = "us-east-1"
 }
 
-variable "aws_access_key" {
+variable "aws_access_key_id" {
 }
 
-variable "aws_secret_key" {
+variable "aws_secret_access_key" {
 }


### PR DESCRIPTION
### Security
- Update NodeJS to version 16 (and update dependencies)

### Fixed
- Use `npm ci` ([docs](https://docs.npmjs.com/cli/v8/commands/npm-ci)) to install dependencies for tests, both locally and on CI/CD system

---

I manually tested this on staging as well, but feel free to do so yourself. The more the merrier.