### PR TITLE
Get python 3 installed on the recover image

### DIFF
--- a/recovery/Dockerfile
+++ b/recovery/Dockerfile
@@ -1,4 +1,10 @@
-FROM node:16
+FROM node:19
+
+RUN apt-get update && \
+    apt-get install -y python3 && \
+    apt-get install -y python3-venv
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
 
 # Install the AWS CLI
 RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
@@ -6,4 +12,4 @@ RUN unzip awscli-bundle.zip
 RUN ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
 # Install the Serverless Framework
-RUN npm install -g serverless@3
+RUN npm install -g serverless@3 && echo "aws version: " && aws --version

--- a/recovery/Dockerfile
+++ b/recovery/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19
+FROM node:18
 
 RUN apt-get update && \
     apt-get install -y python3 && \


### PR DESCRIPTION
This is for
https://trello.com/c/Zy1N5NfM/531-fix-serverless-mfa-apis-do-full-recovery-docker-image-process

Is there a way to safely test it?