### PR TITLE
Add new Global Table for API Keys

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -28,7 +28,7 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-        Resource: "arn:aws:dynamodb:${aws:region}:*:table/${self:custom.namespace}_*"
+        Resource: "arn:aws:dynamodb:*:*:table/${self:custom.namespace}_*"
 
 custom:
   namespace: ${self:service}_${sls:stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -192,6 +192,29 @@ functions:
 
 resources:
   Resources:
+    ApiKeyDynamoDbGlobalTable:
+      Type: AWS::DynamoDB::GlobalTable
+      DeletionPolicy: Retain
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: value
+            AttributeType: S
+        KeySchema:
+          - AttributeName: value
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        Replicas:
+          - Region: ${aws:region}
+            Tags:
+              - Key: "itse_app_name"
+                Value: ${self:service}
+              - Key: "itse_app_env"
+                Value: ${self:custom.${sls:stage}_env}
+              - Key: "itse_app_customer"
+                Value: "shared"
+              - Key: "managed_by"
+                Value: "serverless"
+        TableName: ${self:custom.apiKeyTable}_global
     ApiKeyDynamoDbTable:
       Type: AWS::DynamoDB::Table
       DeletionPolicy: Retain

--- a/serverless.yml
+++ b/serverless.yml
@@ -204,7 +204,7 @@ resources:
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
         Replicas:
-          - Region: ${aws:region}
+          - Region: "us-east-2" # Temporarily hard-code this as part of an upcoming move.
             Tags:
               - Key: "itse_app_name"
                 Value: ${self:service}


### PR DESCRIPTION
### Added
- Add new Global Table for API Keys
  * ... temporarily hard-coded to be in `us-east-2`, so that the stack controlling the GlobalTable will be there.

### Fixed
- Allow the functions to access the DynamoDB tables in any region