### PR TITLE
Stop hard-coding a different region for the GlobalTable

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -204,7 +204,7 @@ resources:
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
         Replicas:
-          - Region: "us-east-2" # Temporarily hard-code this as part of an upcoming move.
+          - Region: ${aws:region}
             Tags:
               - Key: "itse_app_name"
                 Value: ${self:service}


### PR DESCRIPTION
### Fixed
- Stop hard-coding a different region for the GlobalTable
  * Apparently the GlobalTable must include a replicate in the same regions as the CloudFormation stack.