### PR TITLE
Add secondary region to API Keys GlobalTable

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -37,6 +37,7 @@ custom:
   u2fTable: ${self:custom.namespace}_u2f
   dev_env: staging
   prod_env: production
+  secondaryRegion: ${env:AWS_REGION_SECONDARY, "us-west-2"}
 
 functions:
   apiKeyActivate:
@@ -205,6 +206,16 @@ resources:
         BillingMode: PAY_PER_REQUEST
         Replicas:
           - Region: ${aws:region}
+            Tags:
+              - Key: "itse_app_name"
+                Value: ${self:service}
+              - Key: "itse_app_env"
+                Value: ${self:custom.${sls:stage}_env}
+              - Key: "itse_app_customer"
+                Value: "shared"
+              - Key: "managed_by"
+                Value: "serverless"
+          - Region: ${self:custom.secondaryRegion}
             Tags:
               - Key: "itse_app_name"
                 Value: ${self:service}

--- a/serverless.yml
+++ b/serverless.yml
@@ -225,6 +225,8 @@ resources:
                 Value: "shared"
               - Key: "managed_by"
                 Value: "serverless"
+        StreamSpecification:
+          StreamViewType: NEW_IMAGE
         TableName: ${self:custom.apiKeyTable}_global
     ApiKeyDynamoDbTable:
       Type: AWS::DynamoDB::Table


### PR DESCRIPTION
### Added
- Add GlobalTable replica in secondary region (defaulting to us-west-2)
- Add the required `StreamSpecification` GlobalTable property
  * I don't know whether we use this at all, but in case the way we back up the data uses the stream, I set it to send the new value. Documentation is [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-globaltable-streamspecification.html).