### PR TITLE
Release 2.5.0

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -200,6 +200,21 @@ resources:
         BillingMode: PAY_PER_REQUEST
         TableName: ${self:custom.apiKeyTable}
         Tags: ${self:custom.resourceTags}
+    TotpDynamoDbGlobalTable:
+      Type: AWS::DynamoDB::GlobalTable
+      DeletionPolicy: Retain
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: uuid
+            AttributeType: S
+        KeySchema:
+          - AttributeName: uuid
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        Replicas: ${self:custom.globalTableReplicas}
+        StreamSpecification:
+          StreamViewType: NEW_IMAGE
+        TableName: ${self:custom.totpTable}_global
     TotpDynamoDbTable:
       Type: AWS::DynamoDB::Table
       DeletionPolicy: Retain
@@ -213,6 +228,21 @@ resources:
         BillingMode: PAY_PER_REQUEST
         TableName: ${self:custom.totpTable}
         Tags: ${self:custom.resourceTags}
+    U2fDynamoDbGlobalTable:
+      Type: AWS::DynamoDB::GlobalTable
+      DeletionPolicy: Retain
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: uuid
+            AttributeType: S
+        KeySchema:
+          - AttributeName: uuid
+            KeyType: HASH
+        BillingMode: PAY_PER_REQUEST
+        Replicas: ${self:custom.globalTableReplicas}
+        StreamSpecification:
+          StreamViewType: NEW_IMAGE
+        TableName: ${self:custom.u2fTable}_global
     U2fDynamoDbTable:
       Type: AWS::DynamoDB::Table
       DeletionPolicy: Retain


### PR DESCRIPTION
### Added
- Add new Global Table for TOTP data
  * Not in use yet. Will migrate data to it after this release, and do a subsequent release to start using this table.
- Add new Global Table for U2F(/WebAuthn) data
  * Not in use yet. Will migrate data to it after this release, and do a subsequent release to start using this table.

### Changed (non-breaking)
- Extract DynamoDB Table `Tags` to custom value for reuse
- Extract function `tags` to custom value for reuse
- Extract GlobalTable `Replicas` to custom value for reuse