### PR TITLE
Use global tables

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -63,7 +63,7 @@ functions:
     handler: handlers/api-key.activate
     name: ${self:custom.namespace}_apiKeyActivate
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
     events:
       - http:
           path: api-key/activate
@@ -74,7 +74,7 @@ functions:
     handler: handlers/api-key.create
     name: ${self:custom.namespace}_apiKeyCreate
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
     events:
       - http:
           path: api-key
@@ -85,7 +85,7 @@ functions:
     handler: handlers/totp.create
     name: ${self:custom.namespace}_totpCreate
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       TOTP_TABLE_NAME: ${self:custom.totpTable}
     events:
       - http:
@@ -96,7 +96,7 @@ functions:
     handler: handlers/totp.delete
     name: ${self:custom.namespace}_totpDelete
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       TOTP_TABLE_NAME: ${self:custom.totpTable}
     events:
       - http:
@@ -107,7 +107,7 @@ functions:
     handler: handlers/totp.validate
     name: ${self:custom.namespace}_totpValidate
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       TOTP_TABLE_NAME: ${self:custom.totpTable}
     events:
       - http:
@@ -118,7 +118,7 @@ functions:
     handler: handlers/u2f.createAuthentication
     name: ${self:custom.namespace}_u2fCreateAuthentication
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       U2F_TABLE_NAME: ${self:custom.u2fTable}
     events:
       - http:
@@ -129,7 +129,7 @@ functions:
     handler: handlers/u2f.createRegistration
     name: ${self:custom.namespace}_u2fCreateRegistration
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       U2F_TABLE_NAME: ${self:custom.u2fTable}
     events:
       - http:
@@ -140,7 +140,7 @@ functions:
     handler: handlers/u2f.delete
     name: ${self:custom.namespace}_u2fDelete
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       U2F_TABLE_NAME: ${self:custom.u2fTable}
     events:
       - http:
@@ -151,7 +151,7 @@ functions:
     handler: handlers/u2f.validateAuthentication
     name: ${self:custom.namespace}_u2fValidateAuthentication
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       U2F_TABLE_NAME: ${self:custom.u2fTable}
     events:
       - http:
@@ -162,7 +162,7 @@ functions:
     handler: handlers/u2f.validateRegistration
     name: ${self:custom.namespace}_u2fValidateRegistration
     environment:
-      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}
+      API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
       U2F_TABLE_NAME: ${self:custom.u2fTable}
     events:
       - http:

--- a/serverless.yml
+++ b/serverless.yml
@@ -86,7 +86,7 @@ functions:
     name: ${self:custom.namespace}_totpCreate
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      TOTP_TABLE_NAME: ${self:custom.totpTable}
+      TOTP_TABLE_NAME: ${self:custom.totpTable}_global
     events:
       - http:
           path: totp
@@ -97,7 +97,7 @@ functions:
     name: ${self:custom.namespace}_totpDelete
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      TOTP_TABLE_NAME: ${self:custom.totpTable}
+      TOTP_TABLE_NAME: ${self:custom.totpTable}_global
     events:
       - http:
           path: totp/{uuid}
@@ -108,7 +108,7 @@ functions:
     name: ${self:custom.namespace}_totpValidate
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      TOTP_TABLE_NAME: ${self:custom.totpTable}
+      TOTP_TABLE_NAME: ${self:custom.totpTable}_global
     events:
       - http:
           path: totp/{uuid}/validate

--- a/serverless.yml
+++ b/serverless.yml
@@ -119,7 +119,7 @@ functions:
     name: ${self:custom.namespace}_u2fCreateAuthentication
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      U2F_TABLE_NAME: ${self:custom.u2fTable}
+      U2F_TABLE_NAME: ${self:custom.u2fTable}_global
     events:
       - http:
           path: u2f/{uuid}/auth
@@ -130,7 +130,7 @@ functions:
     name: ${self:custom.namespace}_u2fCreateRegistration
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      U2F_TABLE_NAME: ${self:custom.u2fTable}
+      U2F_TABLE_NAME: ${self:custom.u2fTable}_global
     events:
       - http:
           path: u2f
@@ -141,7 +141,7 @@ functions:
     name: ${self:custom.namespace}_u2fDelete
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      U2F_TABLE_NAME: ${self:custom.u2fTable}
+      U2F_TABLE_NAME: ${self:custom.u2fTable}_global
     events:
       - http:
           path: u2f/{uuid}
@@ -152,7 +152,7 @@ functions:
     name: ${self:custom.namespace}_u2fValidateAuthentication
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      U2F_TABLE_NAME: ${self:custom.u2fTable}
+      U2F_TABLE_NAME: ${self:custom.u2fTable}_global
     events:
       - http:
           path: u2f/{uuid}/auth
@@ -163,7 +163,7 @@ functions:
     name: ${self:custom.namespace}_u2fValidateRegistration
     environment:
       API_KEY_TABLE_NAME: ${self:custom.apiKeyTable}_global
-      U2F_TABLE_NAME: ${self:custom.u2fTable}
+      U2F_TABLE_NAME: ${self:custom.u2fTable}_global
     events:
       - http:
           path: u2f/{uuid}


### PR DESCRIPTION
### Changed (BREAKING)
- Configure the functions to use the new global api-key table
- Configure the functions to use the new global u2f table
- Configure the functions to use the new global totp table

---

**WARNING:** Before deploying this, the data from the non-global tables will need to be copied to the global tables. The easiest way to do this is to restore data from the non-global tables' automated backups to the global tables, as [described in the README.md file](https://github.com/silinternational/serverless-mfa-api/blob/6c0aed9a1c5234e42a78dec1b6ef4f9e6ddbb95c/README.md?plain=1#L252-L263).

For example, to restore the dev tier of the api-keys table's data to the api-keys_global table, you could run this:

```bash
gulp restore \
  --s3bucket "yourorg.backups.dynamodb.mfa-api" \
  --s3prefix "mfa-api_dev_api-key" \
  --s3region "us-east-1" \
  --dbtable "mfa-api_dev_api-key_global" \
  --dbregion "us-east-1" \
  --restoretime 1685555967459
```

You may also want to do that restore again immediately after you make the switchover, in case any data was changed between the time specified in your initial restore and when this application update was deployed, changing the code to use the new tables.

I (@forevermatt) will do this for our instance(s) of this application.