### PR TITLE
Also deploy to Lambdas to secondary region

### DIFF
--- a/codeship/deploy.sh
+++ b/codeship/deploy.sh
@@ -9,6 +9,10 @@ set -x
 # Print the Serverless version in the logs
 serverless --version
 
+# NOTE: The regions are hard-coded here (to specify where the AWS Lambda
+# functions should be deployed to), but are provided via variables in terraform
+# (to control where the DynamoDB GlobalTables exist). If you want them to be in
+# the same regions, set the terraform variables to match these:
 echo "Deploying stage $1..."
 serverless deploy --verbose --stage "$1" --region us-east-1
 serverless deploy --verbose --stage "$1" --region us-west-2

--- a/codeship/deploy.sh
+++ b/codeship/deploy.sh
@@ -11,3 +11,4 @@ serverless --version
 
 echo "Deploying stage $1..."
 serverless deploy --verbose --stage "$1" --region us-east-1
+serverless deploy --verbose --stage "$1" --region us-west-2

--- a/codeship/deploy.sh
+++ b/codeship/deploy.sh
@@ -3,6 +3,9 @@
 # Exit script with error if any step fails.
 set -e
 
+# Echo out all commands for monitoring progress
+set -x
+
 # Print the Serverless version in the logs
 serverless --version
 

--- a/codeship/deploy.sh
+++ b/codeship/deploy.sh
@@ -10,4 +10,4 @@ set -x
 serverless --version
 
 echo "Deploying stage $1..."
-serverless deploy --verbose --stage "$1"
+serverless deploy --verbose --stage "$1" --region us-east-1


### PR DESCRIPTION
### Changed (non-breaking)
- Show more of the output of commands during a deployment
- Explicitly specify the region of our normal (primary) deployment

### Added
- Also deploy to a secondary region
- Add comment about multiple places the region(s) is/are specified