### PR TITLE
Fix ttl value for Cloudflare DNS record

### DIFF
--- a/terraform/modules/fail-over-cname/main.tf
+++ b/terraform/modules/fail-over-cname/main.tf
@@ -12,7 +12,7 @@ resource "cloudflare_record" "public-cname" {
   comment = "For easy fail over. ${local.primary_region_summary} / ${local.secondary_region_summary}"
   name    = "${var.subdomain}.${var.cloudflare_zone_name}"
   proxied = true
-  ttl     = 60 # seconds
+  ttl     = 1 # ttl must be set to 1 when proxied is true
   type    = "CNAME"
   value   = var.primary_region_domain_name
   zone_id = data.cloudflare_zone.this.id


### PR DESCRIPTION
### Fixed
- Fix ttl value for Cloudflare DNS record (must be 1 when proxied is true)

---

I only know this because that was the error message that came back when I tried to apply the terraform plan.