### PR TITLE
Deprecate output names with hyphens, add new outputs with underscores

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,9 +1,23 @@
 
+/* Old names, using hyphens. Will be removed in next major release: */
+
 output "serverless-access-key-id" {
   value = one(module.serverless-user[*].aws_access_key_id)
 }
 
 output "serverless-secret-access-key" {
+  value     = one(module.serverless-user[*].aws_secret_access_key)
+  sensitive = true
+}
+
+
+/* New names, using underscores: */
+
+output "serverless_access_key_id" {
+  value = one(module.serverless-user[*].aws_access_key_id)
+}
+
+output "serverless_secret_access_key" {
   value     = one(module.serverless-user[*].aws_secret_access_key)
   sensitive = true
 }


### PR DESCRIPTION
### Added
- Add `serverless_access_key_id` output
- Add `serverless_secret_access_key` output

### Deprecated
- Deprecate `serverless-access-key-id` output (but leave in place for now)
- Deprecate `serverless-secret-access-key` output (but leave in place for now)