### PR TITLE
Change Cloudflare zone/domain name variable

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,7 +84,7 @@ module "dns_for_failover" {
   source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.2.0"
 
   app_name             = var.app_name
-  cloudflare_zone_name = var.cloudflare_zone_name
+  cloudflare_zone_name = var.cloudflare_domain
   serverless_stage     = local.app_env
 
   providers = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,7 +19,7 @@ variable "cloudflare_token" {
   type        = string
 }
 
-variable "cloudflare_zone_name" {
+variable "cloudflare_domain" {
   description = "Cloudflare zone (domain) for DNS records"
   type        = string
 }


### PR DESCRIPTION
### Fixed
- Change variable `cloudflare_zone_name` to `cloudflare_domain` for consistency and because our Terraform Cloud variable set uses the variable name `cloudflare_domain`.
