### PR TITLE
Use updated dns-for-failover module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,7 +81,8 @@ module "serverless_user" {
  * Manage custom domain name resources (used primarily to ease failovers).
  */
 module "dns_for_failover" {
-  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.3.0"
+  source  = "silinternational/serverless-api-dns-for-failover/aws"
+  version = "0.3.0"
 
   api_name             = "${local.app_env}-${var.app_name}"
   cloudflare_zone_name = var.cloudflare_zone_name

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,11 +81,12 @@ module "serverless_user" {
  * Manage custom domain name resources (used primarily to ease failovers).
  */
 module "dns_for_failover" {
-  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.2.0"
+  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.3.0"
 
-  app_name             = var.app_name
+  api_name             = "${local.app_env}-${var.app_name}"
   cloudflare_zone_name = var.cloudflare_zone_name
   serverless_stage     = local.app_env
+  subdomain            = var.app_name
 
   providers = {
     aws           = aws


### PR DESCRIPTION
### Fixed
- Use updated version of dns-for-failover module, with new variables
- Access the dns-for-failover module via the terraform registry, not URL