### PR TITLE
Pre-release 3.0.0-pre2 - Switch to using the GlobalTable for api-keys

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
 
 custom:
   namespace: ${self:service}_${sls:stage}
-  apiKeyTable: ${self:custom.namespace}_api-key
+  apiKeyTable: ${self:custom.namespace}_api-key_global
   totpTable: ${self:custom.namespace}_totp
   u2fTable: ${self:custom.namespace}_u2f
   dev_env: staging


### PR DESCRIPTION
### Change (BREAKING)
- Switch to using the GlobalTable for api-keys