### PR TITLE
Pre-release 3.0.0-pre4 - Switch to using the GlobalTable for u2f records (irrelevant)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -34,7 +34,7 @@ custom:
   namespace: ${self:service}_${sls:stage}
   apiKeyTable: ${self:custom.namespace}_api-key_global
   totpTable: ${self:custom.namespace}_totp_global
-  u2fTable: ${self:custom.namespace}_u2f
+  u2fTable: ${self:custom.namespace}_u2f_global
   dev_env: staging
   prod_env: production
   secondaryRegion: ${env:AWS_REGION_SECONDARY, "us-west-2"}


### PR DESCRIPTION
### Changed (BREAKING)
- Switch to using the GlobalTable for u2f records (irrelevant)
  * Note: This particular change doesn't matter because it's the serverless-mfa-api-go code that handles U2F and WebAuthn now.