### PR TITLE
Use updated dns-for-failover module to add intermediate CNAMEs

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,7 +82,7 @@ module "serverless_user" {
  */
 module "dns_for_failover" {
   source  = "silinternational/serverless-api-dns-for-failover/aws"
-  version = "0.4.0"
+  version = "0.5.0"
 
   api_name             = "${local.app_env}-${var.app_name}"
   cloudflare_zone_name = var.cloudflare_domain


### PR DESCRIPTION
### Added
- Use updated dns-for-failover module to add intermediate CNAMEs

---

Here are the release notes for that:
https://github.com/silinternational/terraform-aws-serverless-api-dns-for-failover/releases/tag/0.5.0