### PR TITLE
Update dns-for-failover module to get public CNAME (and later) fix(es)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,7 +82,7 @@ module "serverless_user" {
  */
 module "dns_for_failover" {
   source  = "silinternational/serverless-api-dns-for-failover/aws"
-  version = "0.5.0"
+  version = "~> 0.5.1"
 
   api_name             = "${local.app_env}-${var.app_name}"
   cloudflare_zone_name = var.cloudflare_domain


### PR DESCRIPTION
### Fixed
- Update dns-for-failover module to get public CNAME (and later) fix(es)