### PR TITLE
Release 3.1.0 - Better failover CNAME DNS records

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
 
 custom:
   namespace: ${self:service}_${sls:stage}
-  apiKeyTable: ${self:custom.namespace}_api-key
+  apiKeyTable: ${self:custom.namespace}_api-key_global
   totpTable: ${self:custom.namespace}_totp
   u2fTable: ${self:custom.namespace}_u2f
   dev_env: staging

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,7 +33,7 @@ provider:
 custom:
   namespace: ${self:service}_${sls:stage}
   apiKeyTable: ${self:custom.namespace}_api-key_global
-  totpTable: ${self:custom.namespace}_totp
+  totpTable: ${self:custom.namespace}_totp_global
   u2fTable: ${self:custom.namespace}_u2f
   dev_env: staging
   prod_env: production

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,7 +34,7 @@ custom:
   namespace: ${self:service}_${sls:stage}
   apiKeyTable: ${self:custom.namespace}_api-key_global
   totpTable: ${self:custom.namespace}_totp_global
-  u2fTable: ${self:custom.namespace}_u2f
+  u2fTable: ${self:custom.namespace}_u2f_global
   dev_env: staging
   prod_env: production
   secondaryRegion: ${env:AWS_REGION_SECONDARY, "us-west-2"}


### PR DESCRIPTION
### Added
- Add intermediate CNAMEs
  * Example of new DNS records:
    - "Public" CNAME: `api.example.com` -->
      * `api-us-east-1.example.com` (for primary region)
      * `api-us-west-w.example.com` (for secondary region)
    - "Intermediate" CNAME (primary): `api-us-east-1.example.com` --> `d-abcde12345.execute-api.us-east-1.amazonaws.com`
    - "Intermediate" CNAME (secondary): `api-us-west-2.example.com` --> `d-zyxwv67890.execute-api.us-west-2.amazonaws.com`
- Add outputs:
  * `primary_region_domain_name` - The domain name to use (as the value of the "public" CNAME record) to use the primary region. Example: `api-us-east-1.example.com`
  * `secondary_region_domain_name` - The domain name to use (as the value of the "public" CNAME record) to use the secondary region. Example: `api-us-west-2.example.com`

### Changed (non-breaking)
- Rename some internal modules to better align with their purpose:
  * `fail-over-cname` --> `fail-over-cnames`
  * `custom_domains` --> `api_gateway_domains_and_certs`
- Rename some other resources to differentiate between public (main) CNAME, intermediate CNAME, and AWS API Gateway domain names.

### Fixed
- Wait for certificate to be issued before trying to use it