### PR TITLE
Turn on Point-In-Time-Recovery (PITR) for our MFA APIs' database tables

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -110,6 +110,10 @@ resource "aws_dynamodb_table" "api_keys" {
     type = "S"
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   replica {
     region_name = var.aws_region_secondary
   }
@@ -130,6 +134,10 @@ resource "aws_dynamodb_table" "totp" {
     type = "S"
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   replica {
     region_name = var.aws_region_secondary
   }
@@ -148,6 +156,10 @@ resource "aws_dynamodb_table" "u2f" {
   attribute {
     name = "uuid"
     type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
   }
 
   replica {


### PR DESCRIPTION
### Added
- Turn on Point-In-Time-Recovery (PITR) for our MFA APIs' database tables

---

It seems like the cost for this will be so ridiculously minimal that there's no reason not to, and it might end up replacing our current way of doing backups.