### PR TITLE
Release 3.2.0 - Point-In-Time-Recovery (PITR) and Deletion-protection

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,7 +82,7 @@ module "serverless_user" {
  */
 module "dns_for_failover" {
   source  = "silinternational/serverless-api-dns-for-failover/aws"
-  version = "0.5.0"
+  version = "~> 0.5.1"
 
   api_name             = "${local.app_env}-${var.app_name}"
   cloudflare_zone_name = var.cloudflare_domain

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -82,7 +82,7 @@ module "serverless_user" {
  */
 module "dns_for_failover" {
   source  = "silinternational/serverless-api-dns-for-failover/aws"
-  version = "0.4.0"
+  version = "0.5.0"
 
   api_name             = "${local.app_env}-${var.app_name}"
   cloudflare_zone_name = var.cloudflare_domain

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -110,6 +110,10 @@ resource "aws_dynamodb_table" "api_keys" {
     type = "S"
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   replica {
     region_name = var.aws_region_secondary
   }
@@ -130,6 +134,10 @@ resource "aws_dynamodb_table" "totp" {
     type = "S"
   }
 
+  point_in_time_recovery {
+    enabled = true
+  }
+
   replica {
     region_name = var.aws_region_secondary
   }
@@ -148,6 +156,10 @@ resource "aws_dynamodb_table" "u2f" {
   attribute {
     name = "uuid"
     type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
   }
 
   replica {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -99,11 +99,12 @@ module "dns_for_failover" {
  * Manage DynamoDB tables used by the functions.
  */
 resource "aws_dynamodb_table" "api_keys" {
-  name             = "${var.app_name}_${local.app_env}_api-key_global"
-  hash_key         = "value"
-  billing_mode     = "PAY_PER_REQUEST"
-  stream_enabled   = true
-  stream_view_type = "NEW_IMAGE"
+  name                        = "${var.app_name}_${local.app_env}_api-key_global"
+  hash_key                    = "value"
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = true
+  stream_enabled              = true
+  stream_view_type            = "NEW_IMAGE"
 
   attribute {
     name = "value"
@@ -123,11 +124,12 @@ resource "aws_dynamodb_table" "api_keys" {
   }
 }
 resource "aws_dynamodb_table" "totp" {
-  name             = "${var.app_name}_${local.app_env}_totp_global"
-  hash_key         = "uuid"
-  billing_mode     = "PAY_PER_REQUEST"
-  stream_enabled   = true
-  stream_view_type = "NEW_IMAGE"
+  name                        = "${var.app_name}_${local.app_env}_totp_global"
+  hash_key                    = "uuid"
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = true
+  stream_enabled              = true
+  stream_view_type            = "NEW_IMAGE"
 
   attribute {
     name = "uuid"
@@ -147,11 +149,12 @@ resource "aws_dynamodb_table" "totp" {
   }
 }
 resource "aws_dynamodb_table" "u2f" {
-  name             = "${var.app_name}_${local.app_env}_u2f_global"
-  hash_key         = "uuid"
-  billing_mode     = "PAY_PER_REQUEST"
-  stream_enabled   = true
-  stream_view_type = "NEW_IMAGE"
+  name                        = "${var.app_name}_${local.app_env}_u2f_global"
+  hash_key                    = "uuid"
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = true
+  stream_enabled              = true
+  stream_view_type            = "NEW_IMAGE"
 
   attribute {
     name = "uuid"


### PR DESCRIPTION
### Added
- Turn on Point-In-Time-Recovery (PITR) for our MFA APIs' database tables
  * It seems like the cost for this will be so ridiculously minimal that there's no reason not to, and it might end up replacing our current way of doing backups.
- Prevent accidental deletion of the MFA APIs' database tables