### PR TITLE
If the API Secret is NOT valid, log its first and last few characters

### DIFF
--- a/models/api-key.js
+++ b/models/api-key.js
@@ -182,6 +182,8 @@ const isValidApiSecret = (apiKeyRecord, apiSecret = '') => {
   const isValid = password.compare(apiSecret, apiKeyRecord.hashedApiSecret);
   if (isValid !== true) {
     console.log('The given API Secret is NOT valid for the given API Key record.');
+    const redactedApiSecret = apiSecret.substring(0, 3) + '...[snip]...' + apiSecret.substring(apiSecret.length - 3);
+    console.log(redactedApiSecret);
     return false;
   }
   


### PR DESCRIPTION
### Added
- If the API Secret is NOT valid, log its first and last few characters
  * This should help us confirm whether, for instance, and equals sign has been dropped from the end of the string.