### PR TITLE
Release 3.1.3 -- log API Secret error, increase log retention

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -2,6 +2,9 @@ name: Test and Deploy
 
 on:
   push:
+    branches: ["**"]
+    paths-ignore:
+    - 'terraform/**'
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ dev-server:
 	node development/server
 
 dynamodb:
-	docker-compose up -d dynamodb
+	docker compose up -d dynamodb
 
 dynamodb-tables: dynamodb
 	./development/create-tables.sh
@@ -11,10 +11,10 @@ list-dev-api-keys:
 	./development/list-api-keys.sh
 
 do-full-recovery:
-	docker-compose run --rm do-full-recovery
+	docker compose run --rm do-full-recovery
 
 test:
-	docker-compose run --rm dev bash -c "npm ci && npm test"
+	docker compose run --rm dev bash -c "npm ci && npm test"
 
 update:
-	docker-compose run --rm dev bash -c "npm update"
+	docker compose run --rm dev bash -c "npm update"

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ To run this locally (such as for development)...
 To start a local container for development of Serverless configuration:
 
 ```
-docker-compose run --rm dev bash
+docker compose run --rm dev bash
 ```
 
 ## Credential Rotation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   do-full-recovery:
     build: recovery

--- a/serverless.yml
+++ b/serverless.yml
@@ -175,50 +175,50 @@ resources:
     ApiKeyActivateLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     ApiKeyCreateLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     TotpCreateLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     TotpDeleteLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     TotpValidateLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     U2fCreateAuthenticationLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     U2fCreateRegistrationLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     U2fDeleteLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     U2fValidateAuthenticationLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}
     U2fValidateRegistrationLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
-        RetentionInDays: "30"
+        RetentionInDays: "60"
         Tags: ${self:custom.resourceTags}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "3.35.0"
   constraints = ">= 2.0.0, < 4.0.0"
   hashes = [
+    "h1:SFvdgX5bTGhOTMhywgjSOWlkET2el7STxdUSzxjz2pc=",
     "h1:pn9uUSAuIE8XgqJuZ9fOs98bRN9qw4o0JHFgmwtbMyI=",
     "zh:13aabc00fee823422831bcc870227650cc765fc4c9622074d24d6d62a4ac0e37",
     "zh:1544405f0ea6b388dad7eb25c434427b2682417396da9186e1b33551e6b4adff",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,10 +10,9 @@ locals {
 module "serverless_user" {
   count   = var.app_environment == "staging" ? 1 : 0
   source  = "silinternational/serverless-user/aws"
-  version = "0.3.2"
+  version = "0.4.2"
 
   app_name           = var.app_name
-  aws_region         = var.aws_region
   aws_region_policy  = "*"
   enable_api_gateway = true
 


### PR DESCRIPTION
### Added
- If the API Secret is NOT valid, log its first and last few characters
  * This should help us confirm whether, for instance, and equals sign has been dropped from the end of the string.

### Changed
- Increased log retention to 60 days ([ITSE-999](https://itse.youtrack.cloud/issue/ITSE-999) Increase Cloudwatch Log retention)