### PR TITLE
Release -- Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "uuid": "^3.4.0"
   },
   "engines": {
-    "node": ">=18.0.0 <19.0.0"
+    "node": ">=20.0.0 <21.0.0"
   },
   "license": "MIT",
   "repository": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ^3.7
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs20.x
   timeout: 30
 
   # Experimented with various memory sizes. Manually calling the totpValidate


### PR DESCRIPTION
[IDP-1606](https://support.gtis.sil.org/issue/IDP-1606) AWS Lambda end of support for Node.js 18

---

### Changed
- Upgrade the Node.js runtime of the application from version 18.x to 20.x. 


---

### PR Checklist
- [x] Put version number in PR title (if merge to main, e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, RAML/OpenAPI, etc.)
- [ ] Unit tests created or updated

